### PR TITLE
Include commit_within config operation

### DIFF
--- a/lib/logstash/outputs/solr_http.rb
+++ b/lib/logstash/outputs/solr_http.rb
@@ -10,7 +10,7 @@ require "uuidtools"
 # started quickly you should use version 4.4 or above in schemaless mode,
 # which will try and guess your fields automatically. To turn that on,
 # you can use the example included in the Solr archive:
-#
+# [source,shell]
 #     tar zxf solr-4.4.0.tgz
 #     cd example
 #     mv solr solr_ #back up the existing sample conf

--- a/lib/logstash/outputs/solr_http.rb
+++ b/lib/logstash/outputs/solr_http.rb
@@ -17,7 +17,7 @@ require "uuidtools"
 #     cp -r example-schemaless/solr/ .  #put the schemaless conf in place
 #     java -jar start.jar   #start Solr
 #
-# You can learn more about Solr at <https://lucene.apache.org/solr/>
+# You can learn more at https://lucene.apache.org/solr/[the Solr home page]
 
 class LogStash::Outputs::SolrHTTP < LogStash::Outputs::Base
   include Stud::Buffer
@@ -32,8 +32,8 @@ class LogStash::Outputs::SolrHTTP < LogStash::Outputs::Base
   # Number of events to queue up before writing to Solr
   config :flush_size, :validate => :number, :default => 100
 
-  # Make sure that documents are committed within this amount of milliseconds
-  config :commit_within, :validate => :number, :default => nil
+  # Instruct solr to commit within this amount of milliseconds
+  config :commit_within_milliseconds, :validate => :number, :default => nil
 
   # Amount of time since the last flush before a flush is done even if
   # the number of buffered events is smaller than flush_size
@@ -75,10 +75,10 @@ class LogStash::Outputs::SolrHTTP < LogStash::Outputs::Base
         documents.push(document)
     end
 
-    if @commit_within.nil?
+    if @commit_within_milliseconds.nil?
       @solr.add documents
     else
-      @solr.add documents, :add_attributes => {:commitWithin => @commit_within}
+      @solr.add documents, :add_attributes => {:commitWithin => @commit_within_milliseconds}
     end
 
     rescue Exception => e


### PR DESCRIPTION
This commit enables you to commit documents within a certain time (in ms) so that your solr core can be updated when a flush happens.

The issue I had is that my core was never updated after a flush, so no log results were showing.  This option allows you to define that commits happen regularly in order to make sure that the core will track changes accordingly.

Commit Within instructs solr to commit within a certain time, allowing you to alter the performance hit this operation has.

Info about this commitwithin is here:  http://wiki.apache.org/solr/CommitWithin
