### PR TITLE
Flush the event buffer on teardown

### DIFF
--- a/lib/logstash/outputs/solr_http.rb
+++ b/lib/logstash/outputs/solr_http.rb
@@ -75,4 +75,10 @@ class LogStash::Outputs::SolrHTTP < LogStash::Outputs::Base
     rescue Exception => e
       @logger.warn("An error occurred while indexing: #{e.message}")
   end #def flush
+
+  public
+  def teardown
+    buffer_flush(:final => true)
+    finished
+  end
 end #class LogStash::Outputs::SolrHTTP


### PR DESCRIPTION
Explicitly flush the event buffers to send all the remaining events to Solr and index them.
Before that, any event in the buffer was lost when stopping logstash.
