### PR TITLE
Updates for Solr 6.4.0 & Logstash 5.2.0.

### DIFF
--- a/lib/logstash/outputs/solr_http.rb
+++ b/lib/logstash/outputs/solr_http.rb
@@ -62,7 +62,7 @@ class LogStash::Outputs::SolrHTTP < LogStash::Outputs::Base
 
     events.each do |event|
         document = event.to_hash()
-        document["@timestamp"] = document["@timestamp"].iso8601 #make the timestamp ISO
+        #document["@timestamp"] = document["@timestamp"].iso8601 #make the timestamp ISO
         if @document_id.nil?
           document ["id"] = UUIDTools::UUID.random_create    #add a unique ID
         else
@@ -71,7 +71,7 @@ class LogStash::Outputs::SolrHTTP < LogStash::Outputs::Base
         documents.push(document)
     end
 
-    @solr.add(documents)
+    @solr.add(documents, :add_attributes => {:commitWithin=>10000})
     rescue Exception => e
       @logger.warn("An error occurred while indexing: #{e.message}")
   end #def flush


### PR DESCRIPTION
iso8601 call was failing against most events.  Also, no events were actually being committed to Solr! Therefore Silk reported no log events to display.  Here's the /etc/logstash/conf.d/solr_pipeline.conf I used:

input {
    beats {
        port => "5044"
    }
}
filter {
    mutate {
        rename => { "@timestamp" => "timestamp_dt" }
    }
    grok {
        match => [ "message",  "%{SYSLOGLINE}" ]
        overwrite => [ "message" ]
    }
    mutate {
        remove_field => [ "offset","input_type","type","tags","@version","beat", "pid", "logsource", "@timestamp", "program" ]
    }
}
output {
    #stdout { codec => rubydebug }

    solr_http {
      solr_url => "http://$SOLR_SERVER:8983/solr/logs"
    }
}

Thanks for contributing to Logstash! If you haven't already signed our CLA, here's a handy link: https://www.elastic.co/contributor-agreement/
